### PR TITLE
fix build error due to missing FEAMR directory

### DIFF
--- a/build/Mkdir.bash
+++ b/build/Mkdir.bash
@@ -18,5 +18,5 @@ mkdir FEBioFluid
 mkdir FEBioXML
 mkdir FECore
 mkdir NumCore
-
+mkdir FEAMR
 


### PR DESCRIPTION
The Mkdir.bash script was not updated to make a FEAMR directory. This fixes it
and makes the build possible without manual intervention. @gateshian 