### PR TITLE
fix penalty computation and plot

### DIFF
--- a/FEBioMech/FEBioMechPlot.cpp
+++ b/FEBioMech/FEBioMechPlot.cpp
@@ -63,6 +63,7 @@ SOFTWARE.*/
 #include "FEContinuousElasticDamage.h"
 #include <FECore/FEMeshAdaptor.h> // for projectToNodes
 #include "FESlidingInterface.h"
+#include "FESlidingElasticInterface.h"
 #include "FETiedContactSurface.h"
 
 //=============================================================================
@@ -446,6 +447,10 @@ bool FEPlotContactArea::Save(FESurface &surf, FEDataStream& a)
 // Plot contact penalty parameter
 bool FEPlotContactPenalty::Save(FESurface& surf, FEDataStream& a)
 {
+
+	FEContactSurface* pcs = dynamic_cast<FEContactSurface*>(&surf);
+	if (pcs == 0) return false;
+
 	FEFacetSlidingSurface* ps = dynamic_cast<FEFacetSlidingSurface*>(&surf);
 	if (ps)
 	{
@@ -455,6 +460,17 @@ bool FEPlotContactPenalty::Save(FESurface& surf, FEDataStream& a)
 		});
 		return true;
 	}
+
+	FESlidingElasticSurface* pse = dynamic_cast<FESlidingElasticSurface*>(&surf);
+	if (pse)
+	{
+		writeAverageElementValue<double>(surf, a, [](const FEMaterialPoint& mp) {
+			const FESlidingElasticSurface::Data& pt = *mp.ExtractData<FESlidingElasticSurface::Data>();
+			return pt.m_epsn;
+			});
+		return true;
+	}
+
 	return false;
 }
 

--- a/FEBioMech/FEContactInterface.cpp
+++ b/FEBioMech/FEContactInterface.cpp
@@ -78,8 +78,13 @@ double FEContactInterface::AutoPenalty(FESurfaceElement& el, FESurface &s)
         // get a material point
         FEMaterialPoint& mp = *pe->GetMaterialPoint(0);
         FEElasticMaterialPoint& pt = *(mp.ExtractData<FEElasticMaterialPoint>());
-        
-        // setup the material point
+
+		// backup the material point
+		mat3d F0 = pt.m_F;
+		double J0 = pt.m_J;
+		mat3ds s0 = pt.m_s;
+
+        // override the material point
         pt.m_F = mat3dd(1.0);
         pt.m_J = 1;
         pt.m_s.zero();
@@ -88,6 +93,11 @@ double FEContactInterface::AutoPenalty(FESurfaceElement& el, FESurface &s)
         tens4ds S = pme->Tangent(mp);
         tens4ds C = S.inverse();
         
+		// restore the material point
+		pt.m_F = F0;
+		pt.m_J = J0;
+		pt.m_s = s0;
+
         // evaluate element surface normal at parametric center
         vec3d t[2];
         s.CoBaseVectors0(el, 0, 0, t);


### PR DESCRIPTION
- Fixed FEContactInterface::AutoPenalty so it does not overwrite element deformation gradient, Jacobian and stress which may break simulation if applied when mesh has been deformed.
- Enabled plotting of penalty for FESlidingElasticSurface.