### PR TITLE
fix-restart

### DIFF
--- a/Documentation/FEBio_User_Manual.lyx
+++ b/Documentation/FEBio_User_Manual.lyx
@@ -4059,8 +4059,12 @@ With the optional arguments, the complete syntax would be:
 
 \begin_layout Standard
 The dump level can set to 1 (= write dump file after each converged time
- step), or 2 (= write dump file after each completed step).
- 
+ step), 2 (= write dump file after each completed step), 
+ or 3 (= write dump file after each converged 
+ \shape italic
+ must-point
+ \shape default
+ ).
 \end_layout
 
 \begin_layout Standard

--- a/FEBio3/FEBioApp.cpp
+++ b/FEBio3/FEBioApp.cpp
@@ -288,8 +288,8 @@ bool FEBioApp::ParseCmdLine(int nargs, char* argv[])
 		else if (strncmp(sz, "-dump", 5) == 0)
 		{
 			ops.dumpLevel = FE_DUMP_MAJOR_ITRS;
-			if (sz[8] == '=') ops.dumpLevel = atoi(sz + 9);
-			if ((ops.dumpLevel < 0) || (ops.dumpLevel > 2))
+			if (sz[5] == '=') ops.dumpLevel = atoi(sz + 6);
+			if ((ops.dumpLevel < 0) || (ops.dumpLevel > 3))
 			{
 				fprintf(stderr, "FATAL ERROR: invalid restart level.\n");
 				return false;

--- a/FEBio3/FEBioCommand.cpp
+++ b/FEBio3/FEBioCommand.cpp
@@ -158,9 +158,10 @@ int FEBioCmd_Restart::run(int nargs, char** argv)
 	printf("Restart level set to: ");
 	switch (dumpLevel)
 	{
-	case FE_DUMP_NEVER     : printf("NEVER (0)\n"); break;
-	case FE_DUMP_MAJOR_ITRS: printf("MAJOR_ITRS (1)\n"); break;
-	case FE_DUMP_STEP      : printf("STEP (2)\n"); break;
+	case FE_DUMP_NEVER      : printf("NEVER (0)\n"); break;
+	case FE_DUMP_MAJOR_ITRS : printf("MAJOR_ITRS (1)\n"); break;
+	case FE_DUMP_STEP       : printf("STEP (2)\n"); break;
+	case FE_DUMP_MUST_POINTS: printf("MUST POINTS (3)\n"); break;
 	default:
 		printf("(unknown value)\n");
 		break;

--- a/FEBioLib/FEBioModel.cpp
+++ b/FEBioLib/FEBioModel.cpp
@@ -587,12 +587,21 @@ void FEBioModel::WriteData(unsigned int nevent)
 //! Dump state to archive for restarts
 void FEBioModel::DumpData(int nevent)
 {
+	// get the current step
+	FEAnalysis* pstep = GetCurrentStep();
 	int ndump = GetDumpLevel();
 	if (ndump == FE_DUMP_NEVER) return;
 
 	bool bdump = false;
-	if ((nevent == CB_STEP_SOLVED) && (ndump == FE_DUMP_STEP)) bdump = true;
-	if ((nevent == CB_MAJOR_ITERS) && (ndump == FE_DUMP_MAJOR_ITRS)) bdump = true;
+	switch (nevent)
+	{
+	case CB_MAJOR_ITERS:
+		if (ndump == FE_DUMP_MAJOR_ITRS) bdump = true;
+		if ((ndump == FE_DUMP_MUST_POINTS) && (pstep->m_timeController) && (pstep->m_timeController->m_nmust >= 0)) bdump = true;
+		break;
+	case CB_STEP_SOLVED: if (ndump == FE_DUMP_STEP) bdump = true; break;
+	}
+	
 	if (bdump)
 	{
 		DumpFile ar(*this);

--- a/FEBioLib/FEBioModel.h
+++ b/FEBioLib/FEBioModel.h
@@ -40,7 +40,8 @@ SOFTWARE.*/
 enum FE_Dump_Level {
 	FE_DUMP_NEVER,			// never write a dump file
 	FE_DUMP_MAJOR_ITRS,		// create a dump file at the end of each converged time step
-	FE_DUMP_STEP			// create a dump file at the end of an analysis step
+	FE_DUMP_STEP,			// create a dump file at the end of an analysis step
+	FE_DUMP_MUST_POINTS     // create a dump file only on must-points
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
* Fixes bug reading dump level from command line (always writing dump file after each converged time step).
* Further enables writing dump file after converged must-point as
   ```
   febio3 -i input.feb -dump=3
   ```