### PR TITLE
Faster normal projection

### DIFF
--- a/FECore/FENormalProjection.cpp
+++ b/FECore/FENormalProjection.cpp
@@ -54,7 +54,7 @@ FESurfaceElement* FENormalProjection::Project(vec3d r, vec3d n, double rs[2])
 {
 	// let's find all the candidate surface elements
 	set<int>selist;
-	m_OT.FindCandidateSurfaceElements(r, n, selist);
+	m_OT.FindCandidateSurfaceElements(r, n, selist, m_rad);
 	
 	// now that we found candidate surface elements, lets see if we can find 
 	// those that intersect the ray, then pick the closest intersection
@@ -98,7 +98,7 @@ FESurfaceElement* FENormalProjection::Project2(vec3d r, vec3d n, double rs[2])
 {
 	// let's find all the candidate surface elements
 	set<int>selist;
-	m_OT.FindCandidateSurfaceElements(r, n, selist);
+	m_OT.FindCandidateSurfaceElements(r, n, selist, m_rad); // TODO: is rad is this absolute coordinates?
 	
 	// now that we found candidate surface elements, lets see if we can find 
 	// those that intersect the ray, then pick the closest intersection
@@ -141,7 +141,7 @@ FESurfaceElement* FENormalProjection::Project3(const vec3d& r, const vec3d& n, d
 {
 	// let's find all the candidate surface elements
 	set<int>selist;
-	m_OT.FindCandidateSurfaceElements(r, n, selist);
+	m_OT.FindCandidateSurfaceElements(r, n, selist, m_rad);
 
 	double g, gmax = -1e99, r2[2] = {rs[0], rs[1]};
 	int imin = -1;

--- a/FECore/FENormalProjection.cpp
+++ b/FECore/FENormalProjection.cpp
@@ -98,7 +98,7 @@ FESurfaceElement* FENormalProjection::Project2(vec3d r, vec3d n, double rs[2])
 {
 	// let's find all the candidate surface elements
 	set<int>selist;
-	m_OT.FindCandidateSurfaceElements(r, n, selist, m_rad); // TODO: is rad is this absolute coordinates?
+	m_OT.FindCandidateSurfaceElements(r, n, selist, m_rad);
 	
 	// now that we found candidate surface elements, lets see if we can find 
 	// those that intersect the ray, then pick the closest intersection

--- a/FECore/FEOctree.cpp
+++ b/FECore/FEOctree.cpp
@@ -188,15 +188,21 @@ bool OTnode::RayIntersectsNode(vec3d p, vec3d n)
 
 //-----------------------------------------------------------------------------
 // Find intersected octree leaves and return a set of their surface elements
-
-void OTnode::FindIntersectedLeaves(vec3d p, vec3d n, set<int>& sel)
+// hjs: use call by reference
+void OTnode::FindIntersectedLeaves(vec3d p, vec3d n, set<int>& sel, double srad)
 {
-	if (RayIntersectsNode(p, n)) {
+	// hjs: check if octree node is within search radius from p.
+	// Note: search radius is not relative as stated in the documentation.
+	bool bNodeWithinSRad = ( (cmin.x - srad <= p.x) && (cmax.x + srad >= p.x) &&
+	                         (cmin.y - srad <= p.y) && (cmax.y + srad >= p.y) &&
+	                         (cmin.z - srad <= p.z) && (cmax.z + srad >= p.z) );
+
+	if (bNodeWithinSRad && RayIntersectsNode(p, n)) {
 		int nc = (int)children.size();
 		// if this node has children, search them for intersections
 		if (nc) {
 			for (int ic=0; ic<nc; ++ic) {
-				children[ic].FindIntersectedLeaves(p, n, sel);
+				children[ic].FindIntersectedLeaves(p, n, sel, srad);
 			}
 		}
 		// otherwise we have reached the smallest intersected node in this
@@ -305,7 +311,7 @@ void FEOctree::Init(const double stol)
 	return;
 }
 
-void FEOctree::FindCandidateSurfaceElements(vec3d p, vec3d n, set<int>& sel)
+void FEOctree::FindCandidateSurfaceElements(vec3d p, vec3d n, set<int>& sel, double srad)
 {
-	root.FindIntersectedLeaves(p, n, sel);
+	root.FindIntersectedLeaves(p, n, sel, srad);
 }

--- a/FECore/FEOctree.cpp
+++ b/FECore/FEOctree.cpp
@@ -188,11 +188,9 @@ bool OTnode::RayIntersectsNode(vec3d p, vec3d n)
 
 //-----------------------------------------------------------------------------
 // Find intersected octree leaves and return a set of their surface elements
-// hjs: use call by reference
 void OTnode::FindIntersectedLeaves(vec3d p, vec3d n, set<int>& sel, double srad)
 {
-	// hjs: check if octree node is within search radius from p.
-	// Note: search radius is not relative as stated in the documentation.
+	// Check if octree node is within search radius from p.
 	bool bNodeWithinSRad = ( (cmin.x - srad <= p.x) && (cmax.x + srad >= p.x) &&
 	                         (cmin.y - srad <= p.y) && (cmax.y + srad >= p.y) &&
 	                         (cmin.z - srad <= p.z) && (cmax.z + srad >= p.z) );

--- a/FECore/FEOctree.h
+++ b/FECore/FEOctree.h
@@ -48,7 +48,7 @@ public:
 	bool ElementIntersectsNode(const int j);
 	void PrintNodeContent();
 	bool RayIntersectsNode(vec3d p, vec3d n);
-	void FindIntersectedLeaves(vec3d p, vec3d n, std::set<int>& sel);
+	void FindIntersectedLeaves(vec3d p, vec3d n, std::set<int>& sel, double srad);
 	void CountNodes(int& nnode, int& nlevel);
 	
 public:
@@ -76,7 +76,7 @@ public:
 	void Init(const double stol);
 	
 	//! find all candidate surface elements intersected by ray
-	void FindCandidateSurfaceElements(vec3d p, vec3d n, std::set<int>& sel);
+	void FindCandidateSurfaceElements(vec3d p, vec3d n, std::set<int>& sel, double srad);
 	
 protected:
 	FESurface*	m_ps;	//!< the surface to search


### PR DESCRIPTION
I was able to reduce the overall solution time by a factor of 3 for structural contact analysis by modifying normal-projection and octree search to only look for intersections in octree nodes within the specified search radius. The result of the simulation was the same.

I noticed that the **search radius** seems to be compared to absolute values in the code, while it is stated in the documentation that it is relative to the diagonal of model's bounding box. Maybe double check this in the code and documentation?