### PR TITLE
Fixed typos in FEBioFluid subdirectory

### DIFF
--- a/FEBioFluid/FEBioFSI.cpp
+++ b/FEBioFluid/FEBioFSI.cpp
@@ -85,7 +85,7 @@ void FEBioFSI::InitModule()
 	febio.AddModuleDependency("biphasic");	// also pulls in "solid"
 
 	//-----------------------------------------------------------------------------
-	// analyis classes (default type must match module name!)
+	// analysis classes (default type must match module name!)
 	REGISTER_FECORE_CLASS(FEFluidFSIAnalysis, "fluid-FSI");
 
 	//-----------------------------------------------------------------------------

--- a/FEBioFluid/FEBioFluid.cpp
+++ b/FEBioFluid/FEBioFluid.cpp
@@ -123,7 +123,7 @@ void FEBioFluid::InitModule()
 		"}");
 
 	//-----------------------------------------------------------------------------
-	// analyis classes (default type must match module name!)
+	// analysis classes (default type must match module name!)
 	REGISTER_FECORE_CLASS(FEFluidAnalysis, "fluid");
 
 //-----------------------------------------------------------------------------
@@ -248,7 +248,7 @@ REGISTER_FECORE_CLASS(FEPlotFluidRelativeReynoldsNumber, "fluid relative Reynold
 REGISTER_FECORE_CLASS(FEPlotFluidSpecificFreeEnergy    , "fluid specific free energy"    );
 REGISTER_FECORE_CLASS(FEPlotFluidSpecificEntropy       , "fluid specific entropy"        );
 REGISTER_FECORE_CLASS(FEPlotFluidSpecificInternalEnergy, "fluid specific internal energy");
-REGISTER_FECORE_CLASS(FEPlotFluidSpecificGageEnthalpy  , "fluid specific gage enthalpy"  );
+REGISTER_FECORE_CLASS(FEPlotFluidSpecificGageEnthalpy  , "fluid specific gauge enthalpy" );
 REGISTER_FECORE_CLASS(FEPlotFluidSpecificFreeEnthalpy  , "fluid specific free enthalpy"  );
 REGISTER_FECORE_CLASS(FEPlotFluidSpecificStrainEnergy  , "fluid specific strain energy"  );
 REGISTER_FECORE_CLASS(FEPlotFluidIsochoricSpecificHeatCapacity, "fluid isochoric specific heat capacity");

--- a/FEBioFluid/FEBioFluid.h
+++ b/FEBioFluid/FEBioFluid.h
@@ -32,7 +32,7 @@ SOFTWARE.*/
 //-----------------------------------------------------------------------------
 //! The FEBioFluid module
 
-//! The FEBioFluid module adds fluid capabilites to FEBio.
+//! The FEBioFluid module adds fluid capabilities to FEBio.
 //!
 namespace FEBioFluid {
 

--- a/FEBioFluid/FEBioFluidPlot.h
+++ b/FEBioFluid/FEBioFluidPlot.h
@@ -530,7 +530,7 @@ public:
 };
 
 //-----------------------------------------------------------------------------
-//! Specific gage enthalpy
+//! Specific gauge enthalpy
 class FEPlotFluidSpecificGageEnthalpy : public FEPlotDomainData
 {
 public:

--- a/FEBioFluid/FEBioFluidSolutes.cpp
+++ b/FEBioFluid/FEBioFluidSolutes.cpp
@@ -87,7 +87,7 @@ void FEBioFluidSolutes::InitModule()
     febio.AddModuleDependency("multiphasic"); // also pulls in solid, biphasic, solutes
     
     //-----------------------------------------------------------------------------
-    // analyis classes (default type must match module name!)
+    // analysis classes (default type must match module name!)
     REGISTER_FECORE_CLASS(FEFluidSolutesAnalysis, "fluid-solutes");
 
 	// monolithic fluid-solutes solver

--- a/FEBioFluid/FEBioMultiphasicFSI.cpp
+++ b/FEBioFluid/FEBioMultiphasicFSI.cpp
@@ -84,7 +84,7 @@ void FEBioMultiphasicFSI::InitModule()
     febio.AddModuleDependency("multiphasic");    // also pulls in solid, biphasic, solutes
     
     //-----------------------------------------------------------------------------
-    // analyis classes (default type must match module name!)
+    // analysis classes (default type must match module name!)
     REGISTER_FECORE_CLASS(FEMultiphasicFSIAnalysis, "multiphasic-FSI");
 
     //-----------------------------------------------------------------------------

--- a/FEBioFluid/FEBioPolarFluid.cpp
+++ b/FEBioFluid/FEBioPolarFluid.cpp
@@ -79,7 +79,7 @@ void FEBioPolarFluid::InitModule()
     febio.AddModuleDependency("fluid");
     
     //-----------------------------------------------------------------------------
-    // analyis classes (default type must match module name!)
+    // analysis classes (default type must match module name!)
     REGISTER_FECORE_CLASS(FEPolarFluidAnalysis, "polar fluid");
     
     //-----------------------------------------------------------------------------

--- a/FEBioFluid/FEBioThermoFluid.cpp
+++ b/FEBioFluid/FEBioThermoFluid.cpp
@@ -89,7 +89,7 @@ void FEBioThermoFluid::InitModule()
     febio.AddModuleDependency("fluid");
 
     //-----------------------------------------------------------------------------
-    // analyis classes (default type must match module name!)
+    // analysis classes (default type must match module name!)
     REGISTER_FECORE_CLASS(FEThermoFluidAnalysis, "thermo-fluid");
 
     //-----------------------------------------------------------------------------

--- a/FEBioFluid/FEBioThermoFluid.h
+++ b/FEBioFluid/FEBioThermoFluid.h
@@ -32,7 +32,7 @@ SOFTWARE.*/
 //-----------------------------------------------------------------------------
 //! The FEBioThermoFluid module
 
-//! The FEBioThermoFluid module adds thermofluid capabilites to FEBio.
+//! The FEBioThermoFluid module adds thermofluid capabilities to FEBio.
 //!
 namespace FEBioThermoFluid {
 

--- a/FEBioFluid/FEBiphasicFSIDomain3D.h
+++ b/FEBioFluid/FEBiphasicFSIDomain3D.h
@@ -82,7 +82,7 @@ public: // overrides from FEElasticDomain
     //! body forces
     void BodyForce(FEGlobalVector& R, FEBodyForce& BF) override;
     
-    //! intertial forces for dynamic problems
+    //! inertial forces for dynamic problems
     void InertialForces(FEGlobalVector& R) override;
     
     //! calculates the global stiffness matrix for this domain
@@ -111,7 +111,7 @@ public:
     //! Calculates the internal stress vector for solid elements
     void ElementInternalForce(FESolidElement& el, vector<double>& fe);
     
-    //! Calculatess external body forces for solid elements
+    //! Calculates external body forces for solid elements
     void ElementBodyForce(FEBodyForce& BF, FESolidElement& elem, vector<double>& fe);
     
     //! Calculates the inertial force vector for solid elements

--- a/FEBioFluid/FEElasticFluid.cpp
+++ b/FEBioFluid/FEElasticFluid.cpp
@@ -46,7 +46,7 @@ double FEElasticFluid::SpecificInternalEnergy(FEMaterialPoint& mp)
 }
 
 //-----------------------------------------------------------------------------
-//! specific gage enthalpy
+//! specific gauge enthalpy
 double FEElasticFluid::SpecificGageEnthalpy(FEMaterialPoint& mp)
 {
     FEThermoFluid* pMat = dynamic_cast<FEThermoFluid*>(GetParent());

--- a/FEBioFluid/FEElasticFluid.h
+++ b/FEBioFluid/FEElasticFluid.h
@@ -41,7 +41,7 @@ public:
     FEElasticFluid(FEModel* pfem) : FEMaterialProperty(pfem) {}
     virtual ~FEElasticFluid() {}
     
-    //! gage pressure
+    //! gauge pressure
     virtual double Pressure(FEMaterialPoint& pt) = 0;
     
     //! tangent of pressure with respect to strain J
@@ -95,7 +95,7 @@ public:
     //! specific internal energy
     double SpecificInternalEnergy(FEMaterialPoint& mp);
     
-    //! specific gage enthalpy
+    //! specific gauge enthalpy
     double SpecificGageEnthalpy(FEMaterialPoint& mp);
     
     //! specific free enthalpy

--- a/FEBioFluid/FEFluidDomain3D.h
+++ b/FEBioFluid/FEFluidDomain3D.h
@@ -75,7 +75,7 @@ public: // overrides from FEElasticDomain
     //! body forces
     void BodyForce(FEGlobalVector& R, FEBodyForce& BF) override;
     
-    //! intertial forces for dynamic problems
+    //! inertial forces for dynamic problems
     void InertialForces(FEGlobalVector& R) override;
     
     //! calculates the global stiffness matrix for this domain
@@ -104,7 +104,7 @@ public:
     //! Calculates the internal stress vector for solid elements
     void ElementInternalForce(FESolidElement& el, vector<double>& fe);
     
-    //! Calculatess external body forces for solid elements
+    //! Calculates external body forces for solid elements
     void ElementBodyForce(FEBodyForce& BF, FESolidElement& elem, vector<double>& fe);
     
     //! Calculates the inertial force vector for solid elements

--- a/FEBioFluid/FEFluidFSIDomain3D.h
+++ b/FEBioFluid/FEFluidFSIDomain3D.h
@@ -81,7 +81,7 @@ public: // overrides from FEElasticDomain
     //! body forces
     void BodyForce(FEGlobalVector& R, FEBodyForce& BF) override;
     
-    //! intertial forces for dynamic problems
+    //! inertial forces for dynamic problems
     void InertialForces(FEGlobalVector& R) override;
     
     //! calculates the global stiffness matrix for this domain
@@ -110,7 +110,7 @@ public:
     //! Calculates the internal stress vector for solid elements
     void ElementInternalForce(FESolidElement& el, vector<double>& fe);
     
-    //! Calculatess external body forces for solid elements
+    //! Calculates external body forces for solid elements
     void ElementBodyForce(FEBodyForce& BF, FESolidElement& elem, vector<double>& fe);
     
     //! Calculates the inertial force vector for solid elements

--- a/FEBioFluid/FEFluidFSISolver.cpp
+++ b/FEBioFluid/FEFluidFSISolver.cpp
@@ -274,7 +274,7 @@ bool FEFluidFSISolver::InitEquations()
 
 	if (m_eq_scheme == EQUATION_SCHEME::BLOCK)
 	{
-		// merge the second and third parition
+		// merge the second and third partition
 		if (m_part.size() == 3)
 		{
 			vector<int> newPart(2);
@@ -508,7 +508,7 @@ void FEFluidFSISolver::UpdateKinematics(vector<double>& ui)
         }
     }
 
-    // make sure the prescribed BCs are fullfilled
+    // make sure the prescribed BCs are fulfilled
 	int nvel = fem.BoundaryConditions();
     for (int i=0; i<nvel; ++i)
     {
@@ -1151,7 +1151,7 @@ bool FEFluidFSISolver::StiffnessMatrix()
 
     // calculate nonlinear constraint stiffness
     // note that this is the contribution of the
-    // constrainst enforced with augmented lagrangian
+    // constraints enforced with augmented lagrangian
     NonLinearConstraintStiffness(LS, tp);    
    
     // add contributions from rigid bodies

--- a/FEBioFluid/FEFluidSolutesDomain3D.h
+++ b/FEBioFluid/FEFluidSolutesDomain3D.h
@@ -88,7 +88,7 @@ public: // overrides from FEElasticDomain
     //! body forces
     void BodyForce(FEGlobalVector& R, FEBodyForce& BF) override;
     
-    //! intertial forces for dynamic problems
+    //! inertial forces for dynamic problems
     void InertialForces(FEGlobalVector& R) override;
     
     //! calculates the global stiffness matrix for this domain
@@ -117,7 +117,7 @@ public:
     //! Calculates the internal stress vector for solid elements
     void ElementInternalForce(FESolidElement& el, vector<double>& fe);
 
-    //! Calculatess external body forces for solid elements
+    //! Calculates external body forces for solid elements
     void ElementBodyForce(FEBodyForce& BF, FESolidElement& elem, vector<double>& fe);
 
     //! Calculates the inertial force vector for solid elements

--- a/FEBioFluid/FEFluidSolutesSolver.cpp
+++ b/FEBioFluid/FEFluidSolutesSolver.cpp
@@ -421,7 +421,7 @@ void FEFluidSolutesSolver::UpdateKinematics(vector<double>& ui)
         }
     }
     
-    // make sure the prescribed velocities are fullfilled
+    // make sure the prescribed velocities are fulfilled
     int nvel = fem.BoundaryConditions();
     for (int i=0; i<nvel; ++i)
     {
@@ -680,7 +680,7 @@ void FEFluidSolutesSolver::PrepStep()
         if (pml.IsActive()) pml.Update();
     }
 
-    // intialize material point data
+    // initialize material point data
     // NOTE: do this before the stresses are updated
     // TODO: does it matter if the stresses are updated before
     //       the material point data is initialized
@@ -1041,7 +1041,7 @@ bool FEFluidSolutesSolver::StiffnessMatrix(FELinearSystem& LS)
     
     // calculate nonlinear constraint stiffness
     // note that this is the contribution of the
-    // constrainst enforced with augmented lagrangian
+    // constraints enforced with augmented lagrangian
     NonLinearConstraintStiffness(LS, tp);
     
     return true;

--- a/FEBioFluid/FEFluidSolver.cpp
+++ b/FEBioFluid/FEFluidSolver.cpp
@@ -343,7 +343,7 @@ void FEFluidSolver::UpdateKinematics(vector<double>& ui)
         }
     }
 
-    // make sure the prescribed velocities are fullfilled
+    // make sure the prescribed velocities are fulfilled
     int nvel = fem.BoundaryConditions();
     for (int i=0; i<nvel; ++i)
     {
@@ -543,7 +543,7 @@ void FEFluidSolver::PrepStep()
         if (pml.IsActive()) pml.Update();
     }
 
-    // intialize material point data
+    // initialize material point data
     // NOTE: do this before the stresses are updated
     // TODO: does it matter if the stresses are updated before
     //       the material point data is initialized
@@ -791,7 +791,7 @@ bool FEFluidSolver::StiffnessMatrix(FELinearSystem& LS)
     
     // calculate nonlinear constraint stiffness
     // note that this is the contribution of the
-    // constrainst enforced with augmented lagrangian
+    // constraints enforced with augmented lagrangian
     NonLinearConstraintStiffness(LS, tp);
     
     return true;

--- a/FEBioFluid/FEIdealGas.cpp
+++ b/FEBioFluid/FEIdealGas.cpp
@@ -83,7 +83,7 @@ void FEIdealGas::Serialize(DumpStream& ar)
 }
 
 //-----------------------------------------------------------------------------
-//! gage pressure
+//! gauge pressure
 double FEIdealGas::Pressure(FEMaterialPoint& mp)
 {
     FEFluidMaterialPoint& fp = *mp.ExtractData<FEFluidMaterialPoint>();

--- a/FEBioFluid/FEIdealGas.h
+++ b/FEBioFluid/FEIdealGas.h
@@ -46,7 +46,7 @@ public:
     //! Serialization
     void Serialize(DumpStream& ar) override;
 
-    //! gage pressure
+    //! gauge pressure
     double Pressure(FEMaterialPoint& pt) override;
     
     //! tangent of pressure with respect to strain J

--- a/FEBioFluid/FELinearElasticFluid.cpp
+++ b/FEBioFluid/FELinearElasticFluid.cpp
@@ -53,7 +53,7 @@ void FELinearElasticFluid::Serialize(DumpStream& ar)
 }
 
 //-----------------------------------------------------------------------------
-//! gage pressure
+//! gauge pressure
 double FELinearElasticFluid::Pressure(FEMaterialPoint& mp)
 {
     FEFluidMaterialPoint& fp = *mp.ExtractData<FEFluidMaterialPoint>();

--- a/FEBioFluid/FELinearElasticFluid.h
+++ b/FEBioFluid/FELinearElasticFluid.h
@@ -45,7 +45,7 @@ public:
     // serialization
     void Serialize(DumpStream& ar) override;
     
-    //! gage pressure
+    //! gauge pressure
     double Pressure(FEMaterialPoint& pt) override;
     
     //! tangent of pressure with respect to strain J

--- a/FEBioFluid/FELogNonlinearElasticFluid.cpp
+++ b/FEBioFluid/FELogNonlinearElasticFluid.cpp
@@ -51,7 +51,7 @@ void FELogNonlinearElasticFluid::Serialize(DumpStream& ar)
 }
 
 //-----------------------------------------------------------------------------
-//! gage pressure
+//! gauge pressure
 double FELogNonlinearElasticFluid::Pressure(FEMaterialPoint& mp)
 {
     FEFluidMaterialPoint& fp = *mp.ExtractData<FEFluidMaterialPoint>();

--- a/FEBioFluid/FELogNonlinearElasticFluid.h
+++ b/FEBioFluid/FELogNonlinearElasticFluid.h
@@ -45,7 +45,7 @@ public:
     // serialization
     void Serialize(DumpStream& ar) override;
 
-    //! gage pressure
+    //! gauge pressure
     double Pressure(FEMaterialPoint& pt) override;
     
     //! tangent of pressure with respect to strain J

--- a/FEBioFluid/FEMultiphasicFSIDomain3D.h
+++ b/FEBioFluid/FEMultiphasicFSIDomain3D.h
@@ -90,7 +90,7 @@ public: // overrides from FEElasticDomain
     //! body forces
     void BodyForce(FEGlobalVector& R, FEBodyForce& BF) override;
     
-    //! intertial forces for dynamic problems
+    //! inertial forces for dynamic problems
     void InertialForces(FEGlobalVector& R) override;
     
     //! calculates the global stiffness matrix for this domain
@@ -119,7 +119,7 @@ public:
     //! Calculates the internal stress vector for solid elements
     void ElementInternalForce(FESolidElement& el, vector<double>& fe);
     
-    //! Calculatess external body forces for solid elements
+    //! Calculates external body forces for solid elements
     void ElementBodyForce(FEBodyForce& BF, FESolidElement& elem, vector<double>& fe);
     
     //! Calculates the inertial force vector for solid elements

--- a/FEBioFluid/FEMultiphasicFSISolver.cpp
+++ b/FEBioFluid/FEMultiphasicFSISolver.cpp
@@ -311,7 +311,7 @@ bool FEMultiphasicFSISolver::InitEquations()
     
     if (m_eq_scheme == EQUATION_SCHEME::BLOCK)
     {
-        // merge the second and third parition
+        // merge the second and third partition
         if (m_part.size() == 3)
         {
             vector<int> newPart(2);
@@ -615,7 +615,7 @@ void FEMultiphasicFSISolver::UpdateKinematics(vector<double>& ui)
         }
     }
     
-    // make sure the prescribed BCs are fullfilled
+    // make sure the prescribed BCs are fulfilled
     int nvel = fem.BoundaryConditions();
     for (int i=0; i<nvel; ++i)
     {
@@ -1342,7 +1342,7 @@ bool FEMultiphasicFSISolver::StiffnessMatrix()
     
     // calculate nonlinear constraint stiffness
     // note that this is the contribution of the
-    // constrainst enforced with augmented lagrangian
+    // constraints enforced with augmented lagrangian
     NonLinearConstraintStiffness(LS, tp);
     
     // calculate the stiffness contributions for the rigid forces

--- a/FEBioFluid/FENonlinearElasticFluid.cpp
+++ b/FEBioFluid/FENonlinearElasticFluid.cpp
@@ -50,7 +50,7 @@ void FENonlinearElasticFluid::Serialize(DumpStream& ar)
 }
 
 //-----------------------------------------------------------------------------
-//! gage pressure
+//! gauge pressure
 double FENonlinearElasticFluid::Pressure(FEMaterialPoint& mp)
 {
     FEFluidMaterialPoint& fp = *mp.ExtractData<FEFluidMaterialPoint>();

--- a/FEBioFluid/FENonlinearElasticFluid.h
+++ b/FEBioFluid/FENonlinearElasticFluid.h
@@ -45,7 +45,7 @@ public:
     // serialization
     void Serialize(DumpStream& ar) override;
 
-    //! gage pressure
+    //! gauge pressure
     double Pressure(FEMaterialPoint& pt) override;
     
     //! tangent of pressure with respect to strain J

--- a/FEBioFluid/FEPolarFluidDomain3D.h
+++ b/FEBioFluid/FEPolarFluidDomain3D.h
@@ -78,7 +78,7 @@ public: // overrides from FEElasticDomain
     //! body moments
     void BodyMoment(FEGlobalVector& R, FEBodyMoment& bm) override;
     
-    //! intertial forces for dynamic problems
+    //! inertial forces for dynamic problems
     void InertialForces(FEGlobalVector& R) override;
     
     //! calculates the global stiffness matrix for this domain
@@ -113,10 +113,10 @@ public:
     //! Calculates the internal stress vector for solid elements
     void ElementInternalForce(FESolidElement& el, vector<double>& fe);
     
-    //! Calculatess external body forces for solid elements
+    //! Calculates external body forces for solid elements
     void ElementBodyForce(FEBodyForce& BF, FESolidElement& elem, vector<double>& fe);
     
-    //! Calculatess external body moments for solid elements
+    //! Calculates external body moments for solid elements
     void ElementBodyMoment(FEBodyMoment& bm, FESolidElement& elem, vector<double>& fe);
     
     //! Calculates the inertial force vector for solid elements

--- a/FEBioFluid/FEPolarFluidSolver.cpp
+++ b/FEBioFluid/FEPolarFluidSolver.cpp
@@ -469,7 +469,7 @@ void FEPolarFluidSolver::UpdateKinematics(vector<double>& ui)
         }
     }
     
-    // make sure the prescribed BCs are fullfilled
+    // make sure the prescribed BCs are fulfilled
     int nvel = fem.BoundaryConditions();
     for (int i=0; i<nvel; ++i)
     {
@@ -1039,7 +1039,7 @@ bool FEPolarFluidSolver::StiffnessMatrix(FELinearSystem& LS)
     
     // calculate nonlinear constraint stiffness
     // note that this is the contribution of the
-    // constrainst enforced with augmented lagrangian
+    // constraints enforced with augmented lagrangian
     NonLinearConstraintStiffness(LS, tp);
     
     return true;

--- a/FEBioFluid/FERealGas.cpp
+++ b/FEBioFluid/FERealGas.cpp
@@ -105,7 +105,7 @@ void FERealGas::Serialize(DumpStream& ar)
 }
 
 //-----------------------------------------------------------------------------
-//! gage pressure
+//! gauge pressure
 double FERealGas::Pressure(FEMaterialPoint& mp)
 {
     FEFluidMaterialPoint& fp = *mp.ExtractData<FEFluidMaterialPoint>();

--- a/FEBioFluid/FERealGas.h
+++ b/FEBioFluid/FERealGas.h
@@ -50,7 +50,7 @@ public:
     //! Serialization
     void Serialize(DumpStream& ar) override;
 
-    //! gage pressure
+    //! gauge pressure
     double Pressure(FEMaterialPoint& pt) override;
     
     //! tangent of pressure with respect to strain J

--- a/FEBioFluid/FERealLiquid.cpp
+++ b/FEBioFluid/FERealLiquid.cpp
@@ -99,7 +99,7 @@ void FERealLiquid::Serialize(DumpStream& ar)
 }
 
 //-----------------------------------------------------------------------------
-//! gage pressure
+//! gauge pressure
 double FERealLiquid::Pressure(FEMaterialPoint& mp)
 {
     FEFluidMaterialPoint& fp = *mp.ExtractData<FEFluidMaterialPoint>();

--- a/FEBioFluid/FERealLiquid.h
+++ b/FEBioFluid/FERealLiquid.h
@@ -50,7 +50,7 @@ public:
     //! Serialization
     void Serialize(DumpStream& ar) override;
 
-    //! gage pressure
+    //! gauge pressure
     double Pressure(FEMaterialPoint& pt) override;
     
     //! tangent of pressure with respect to strain J
@@ -100,7 +100,7 @@ public:
     double      m_Pr;       //!< referential absolute pressure
     double      m_Tr;       //!< referential absolute temperature
     double      m_rhor;     //!< referential mass density
-    FEFunction1D*   m_psat;         //!< normalized gage pressure on saturation curve (multiply by m_Pr to get actual value)
+    FEFunction1D*   m_psat;         //!< normalized gauge pressure on saturation curve (multiply by m_Pr to get actual value)
     FEFunction1D*   m_asat;         //!< normalized specific free energy on saturation curve (multiply by m_Pr/m_rhor to get actual value)
     FEFunction1D*   m_ssat;         //!< normalized specific entropy on saturation curve (multiply by m_Pr/m_rhor*m_Tr to get actual value)
     FEFunction1D*   m_esat;         //!< dilatation on saturation curve

--- a/FEBioFluid/FERealVapor.cpp
+++ b/FEBioFluid/FERealVapor.cpp
@@ -117,7 +117,7 @@ void FERealVapor::Serialize(DumpStream& ar)
 }
 
 //-----------------------------------------------------------------------------
-//! gage pressure
+//! gauge pressure
 double FERealVapor::Pressure(FEMaterialPoint& mp)
 {
     FEFluidMaterialPoint& fp = *mp.ExtractData<FEFluidMaterialPoint>();

--- a/FEBioFluid/FERealVapor.h
+++ b/FEBioFluid/FERealVapor.h
@@ -49,7 +49,7 @@ public:
     //! Serialization
     void Serialize(DumpStream& ar) override;
 
-    //! gage pressure
+    //! gauge pressure
     double Pressure(FEMaterialPoint& pt) override;
     
     //! tangent of pressure with respect to strain J
@@ -98,7 +98,7 @@ public:
     int             m_nvp;          //!< number of virial coefficients for pressure
     int             m_nvc;          //!< number of virial coefficients for isochoric specific heat capacity
     FEFunction1D*   m_B[MAX_NVP];   //!< non-dimensional pressure coefficient (multiply by m_Pr to get actual value)
-    FEFunction1D*   m_psat;         //!< normalized gage pressure on saturation curve (multiply by m_Pr to get actual value)
+    FEFunction1D*   m_psat;         //!< normalized gauge pressure on saturation curve (multiply by m_Pr to get actual value)
     FEFunction1D*   m_asat;         //!< normalized specific free energy on saturation curve (multiply by m_Pr/m_rhor to get actual value)
     FEFunction1D*   m_ssat;         //!< normalized specific entropy on saturation curve (multiply by m_Pr/m_rhor*m_Tr to get actual value)
     FEFunction1D*   m_esat;         //!< dilatation on saturation curve

--- a/FEBioFluid/FESolutesSolver.cpp
+++ b/FEBioFluid/FESolutesSolver.cpp
@@ -292,7 +292,7 @@ void FESolutesSolver::UpdateKinematics(vector<double>& ui)
     }
     
 
-    // make sure the prescribed dofs are fullfilled
+    // make sure the prescribed dofs are fulfilled
     int nbc = fem.BoundaryConditions();
     for (int i=0; i<nbc; ++i)
     {
@@ -503,7 +503,7 @@ void FESolutesSolver::PrepStep()
         if (pml.IsActive() && HasActiveDofs(pml.GetDofList())) pml.Update();
     }
 
-    // intialize material point data
+    // initialize material point data
     // NOTE: do this before the stresses are updated
     // TODO: does it matter if the stresses are updated before
     //       the material point data is initialized

--- a/FEBioFluid/FEThermoFluidDomain3D.h
+++ b/FEBioFluid/FEThermoFluidDomain3D.h
@@ -82,7 +82,7 @@ public: // overrides from FEElasticDomain
     //! Calculate the heat supply
     void HeatSupply(FEGlobalVector& R, FEFluidHeatSupply& r);
 
-    //! intertial forces for dynamic problems
+    //! inertial forces for dynamic problems
     void InertialForces(FEGlobalVector& R) override;
     
     //! calculates the global stiffness matrix for this domain
@@ -117,10 +117,10 @@ public:
     //! Calculates the internal stress vector for solid elements
     void ElementInternalForce(FESolidElement& el, vector<double>& fe);
     
-    //! Calculatess external body forces for solid elements
+    //! Calculates external body forces for solid elements
     void ElementBodyForce(FEBodyForce& BF, FESolidElement& elem, vector<double>& fe);
     
-    //! Calculatess external supplies for solid elements
+    //! Calculates external supplies for solid elements
     void ElementHeatSupply(FEFluidHeatSupply& BF, FESolidElement& elem, vector<double>& fe);
     
     //! Calculates the inertial force vector for solid elements

--- a/FEBioFluid/FEThermoFluidSolver.cpp
+++ b/FEBioFluid/FEThermoFluidSolver.cpp
@@ -452,7 +452,7 @@ void FEThermoFluidSolver::UpdateKinematics(vector<double>& ui)
         }
     }
     
-    // make sure the prescribed velocities are fullfilled
+    // make sure the prescribed velocities are fulfilled
     int nvel = fem.BoundaryConditions();
     for (int i=0; i<nvel; ++i)
     {
@@ -666,7 +666,7 @@ void FEThermoFluidSolver::PrepStep()
         if (pml.IsActive()) pml.Update();
     }
 
-    // intialize material point data
+    // initialize material point data
     // NOTE: do this before the stresses are updated
     // TODO: does it matter if the stresses are updated before
     //       the material point data is initialized
@@ -996,7 +996,7 @@ bool FEThermoFluidSolver::StiffnessMatrix(FELinearSystem& LS)
     
     // calculate nonlinear constraint stiffness
     // note that this is the contribution of the
-    // constrainst enforced with augmented lagrangian
+    // constraints enforced with augmented lagrangian
     NonLinearConstraintStiffness(LS, tp);
     
     return true;

--- a/FEBioFluid/FETiedFluidInterface.cpp
+++ b/FEBioFluid/FETiedFluidInterface.cpp
@@ -331,7 +331,7 @@ void FETiedFluidInterface::CalcAutoPressurePenalty(FETiedFluidSurface& s)
         // calculate a penalty
         double eps = AutoPressurePenalty(el, s);
         
-        // assign to integation points of surface element
+        // assign to integration points of surface element
         int nint = el.GaussPoints();
         for (int j=0; j<nint; ++j)
         {


### PR DESCRIPTION
Various source comment typo fixes within `FEBioFluid/`